### PR TITLE
fixup player check

### DIFF
--- a/src/js/tech/tech.js
+++ b/src/js/tech/tech.js
@@ -484,6 +484,15 @@ class Tech extends Component {
   }
 
   /**
+   * Start playback
+   *
+   * @abstract
+   *
+   * @see {Html5#play}
+   */
+  play() {}
+
+  /**
    * Set whether we are scrubbing or not
    *
    * @abstract

--- a/test/unit/tracks/text-track-display.test.js
+++ b/test/unit/tracks/text-track-display.test.js
@@ -57,8 +57,8 @@ QUnit.test('if native text tracks are not supported, create a texttrackdisplay',
   const fakeTTDSpy = sinon.spy();
 
   class FakeTTD extends Component {
-    constructor() {
-      super();
+    constructor(player, options) {
+      super(player, options);
       fakeTTDSpy();
     }
   }


### PR DESCRIPTION
- As part of the langauge change, we add an event handler on this.player_.
This causes a bunch of test failures. This is because in the Component
constructor we make sure that this.player_ is set to `this` but only if
a play method is available. This works fine for the Html5 tech or any
tech that implements the play method (all techs) but a lot of our tests
use Tech directly. Adding the abstract method makes those tests pass.
- make sure that the player gets passed up in TTD test
